### PR TITLE
Convert generator to list before generate batches

### DIFF
--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -126,7 +126,7 @@ async def action_pull_station_history(integration, action_config: PullStationHis
             logger.info(f"Extracted {len(history_response.History)} observations for station {action_config.station.Station_ID}.")
             transformed_data = transform(action_config.station, history_response)
 
-            for i, batch in enumerate(generate_batches(transformed_data, 200)):
+            for i, batch in enumerate(generate_batches(list(transformed_data), 200)):
                 logger.info(f'Sending observations batch #{i}: {len(batch)} observations. station: {action_config.station.Station_ID}')
                 response = await send_observations_to_gundi(observations=batch, integration_id=integration.id)
                 observations_extracted += len(response)


### PR DESCRIPTION
This pull request includes a small change to the `app/actions/handlers.py` file. The change ensures that the `transformed_data` is converted to a list before being passed to the `generate_batches` function.

* [`app/actions/handlers.py`](diffhunk://#diff-f575ea29ea1c9649ccb87f9c38a0fd9a78b9f210c9e5e9d800e328ee30d08113L129-R129): Modified the `action_pull_station_history` function to convert `transformed_data` to a list before generating batches.