### PR TITLE
GUNDI-4199: Use `conditions` endpoint for the station readings

### DIFF
--- a/app/actions/client.py
+++ b/app/actions/client.py
@@ -54,7 +54,7 @@ class ConditionsItem(pydantic.BaseModel):
         return v
 
 
-class Unites(pydantic.BaseModel):
+class Units(pydantic.BaseModel):
     local_time_last_update: str
     ts: str
     temperature: str
@@ -69,7 +69,7 @@ class Unites(pydantic.BaseModel):
 
 class ConditionsResponse(pydantic.BaseModel):
     conditions: List[ConditionsItem]
-    unites: Unites
+    units: Units = pydantic.Field(alias='unites')
     generated_at: datetime
     code: int
     message: str
@@ -79,6 +79,9 @@ class ConditionsResponse(pydantic.BaseModel):
         if not v.tzinfo:
             return v.replace(tzinfo=timezone.utc)
         return v
+
+    class Config:
+        allow_population_by_field_name = True
 
 
 class VWException(Exception):

--- a/app/actions/configurations.py
+++ b/app/actions/configurations.py
@@ -23,10 +23,8 @@ class PullObservationsConfig(PullActionConfiguration):
     )
 
 
-class PullStationHistoryConfig(InternalActionConfiguration):
+class PullStationConditionsConfig(InternalActionConfiguration):
     station: Station
-    from_timestamp: int
-    to_timestamp: int
 
 
 def get_auth_config(integration):

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -3,9 +3,7 @@ import logging
 
 import app.actions.client as client
 
-from datetime import datetime, timedelta, timezone
-from math import ceil
-from app.actions.configurations import AuthenticateConfig, PullObservationsConfig, PullStationHistoryConfig, get_auth_config
+from app.actions.configurations import AuthenticateConfig, PullObservationsConfig, PullStationConditionsConfig, get_auth_config
 from app.services.action_scheduler import trigger_action
 from app.services.activity_logger import activity_logger
 from app.services.gundi import send_observations_to_gundi
@@ -20,14 +18,14 @@ VW_BASE_URL = "https://www.vitalweather.co.za/api/v1"
 
 
 def transform(station, observations):
-    def match_units(history, units):
-        for record in history:
+    def match_units(conditions, units):
+        for record in conditions:
             for key, value in record.items():
                 if key in units and key != "ts":
                     record[key] = f"{value} {units[key]}"
-        return history
+        return conditions
 
-    readings = match_units([h.dict(by_alias=True) for h in observations.History], observations.unites.dict())
+    readings = match_units([h.dict() for h in observations.conditions], observations.unites.dict())
 
     for reading in readings:
         yield {
@@ -75,28 +73,14 @@ async def action_pull_observations(integration, action_config: PullObservationsC
         response = await client.get_stations(integration, base_url, auth_config)
         if response:
             logger.info(f"Found {len(response.stations)} stations for integration {integration.id}")
-            now = datetime.now(timezone.utc)
             stations_triggered = 0
             for station in response.stations:
-                logger.info(f"Triggering 'action_pull_station_history' action for station {station.Station_ID} to extract observations...")
-                device_state = await state_manager.get_state(
-                    integration_id=integration.id,
-                    action_id="pull_observations",
-                    source_id=str(station.Station_ID)
-                )
-                if not device_state:
-                    logger.info(f"Setting initial lookback days for station {station.Station_ID} to {action_config.default_lookback_days}")
-                    start = ceil((now - timedelta(days=action_config.default_lookback_days)).timestamp())
-                else:
-                    logger.info(f"Setting begin time for station {station.Station_ID} to {device_state.get('updated_at')}")
-                    start = device_state.get("updated_at")
+                logger.info(f"Triggering 'action_pull_station_conditions' action for station {station.Station_ID} to extract observations...")
 
-                parsed_config = PullStationHistoryConfig(
-                    station=station,
-                    from_timestamp=start,
-                    to_timestamp=ceil(now.timestamp())
+                parsed_config = PullStationConditionsConfig(
+                    station=station
                 )
-                await trigger_action(integration.id, "pull_station_history", config=parsed_config)
+                await trigger_action(integration.id, "pull_station_conditions", config=parsed_config)
                 stations_triggered += 1
             return {"stations_triggered": stations_triggered}
         else:
@@ -113,34 +97,23 @@ async def action_pull_observations(integration, action_config: PullObservationsC
 
 
 @activity_logger()
-async def action_pull_station_history(integration, action_config: PullStationHistoryConfig):
-    logger.info(f"Executing action 'pull_station_history' for integration ID {integration.id} and action_config {action_config}...")
+async def action_pull_station_conditions(integration, action_config: PullStationConditionsConfig):
+    logger.info(f"Executing action 'pull_station_conditions' for integration ID {integration.id} and action_config {action_config}...")
 
     base_url = integration.base_url or VW_BASE_URL
     auth_config = get_auth_config(integration)
     observations_extracted = 0
 
     try:
-        history_response = await client.get_station_history(integration, base_url, action_config, auth_config)
-        if history_response:
-            logger.info(f"Extracted {len(history_response.History)} observations for station {action_config.station.Station_ID}.")
-            transformed_data = transform(action_config.station, history_response)
+        conditions_response = await client.get_station_conditions(integration, base_url, action_config, auth_config)
+        if conditions_response:
+            logger.info(f"Extracted {len(conditions_response.conditions)} observations for station {action_config.station.Station_ID}.")
+            transformed_data = transform(action_config.station, conditions_response)
 
             for i, batch in enumerate(generate_batches(list(transformed_data), 200)):
                 logger.info(f'Sending observations batch #{i}: {len(batch)} observations. station: {action_config.station.Station_ID}')
                 response = await send_observations_to_gundi(observations=batch, integration_id=integration.id)
                 observations_extracted += len(response)
-
-            # Save latest device updated_at
-            latest_time = max(history_response.History, key=lambda obs: obs.ts).ts
-            state = {"updated_at": ceil(latest_time.timestamp())}
-
-            await state_manager.set_state(
-                integration_id=integration.id,
-                action_id="pull_observations",
-                state=state,
-                source_id=str(action_config.station.Station_ID)
-            )
 
             return {"observations_extracted": observations_extracted}
         else:

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -25,7 +25,7 @@ def transform(station, observations):
                     record[key] = f"{value} {units[key]}"
         return conditions
 
-    readings = match_units([h.dict() for h in observations.conditions], observations.unites.dict())
+    readings = match_units([h.dict() for h in observations.conditions], observations.units.dict())
 
     for reading in readings:
         yield {


### PR DESCRIPTION
### Relevant Link

https://allenai.atlassian.net/browse/GUNDI-4199

**NOTE: This refactor disables the historical data loading, since this new endpoint doesn't take any dates as parameters, only returns the latest readings per station.**

---

This pull request introduces a significant refactor to rename and update the functionality related to station data handling. The changes replace "history" terminology with "conditions" to better align with the updated API and data model. 

Key updates include renaming classes, methods, and variables, modifying data models, and updating tests accordingly.

### Data Model Updates:
* Renamed `HistoryItem` to `ConditionsItem` and updated its fields to match the new API response structure, including changes like `wind_average` replacing `wind_avg` and the addition of `FDI` (`app/actions/client.py`, [app/actions/client.pyL36-R47](diffhunk://#diff-2ec2ed70abf8182f30b27698f142fa49dc3f1539f86eb84d0e5826523cb83013L36-R47)).
* Renamed `HistoryResponse` to `ConditionsResponse` and updated its structure to use `conditions` instead of `History` (`app/actions/client.py`, [app/actions/client.pyL72-R71](diffhunk://#diff-2ec2ed70abf8182f30b27698f142fa49dc3f1539f86eb84d0e5826523cb83013L72-R71)).

### API and Logic Adjustments:
* Renamed `get_station_history` to `get_station_conditions` and updated the API endpoint and parameters to fetch the latest conditions instead of historical data (`app/actions/client.py`, [app/actions/client.pyL142-R152](diffhunk://#diff-2ec2ed70abf8182f30b27698f142fa49dc3f1539f86eb84d0e5826523cb83013L142-R152)).
* Removed time range parameters (`from_timestamp`, `to_timestamp`) from the configuration and logic, as they are no longer needed for the new endpoint (`app/actions/configurations.py`, [[1]](diffhunk://#diff-0c07ea434f0a65b6e42dfb436000af783a7bd80e905bbed3d9cb7f67b779d895L26-L29); `app/actions/handlers.py`, [[2]](diffhunk://#diff-f575ea29ea1c9649ccb87f9c38a0fd9a78b9f210c9e5e9d800e328ee30d08113L78-R83).

### Handler and Workflow Changes:
* Refactored the `action_pull_station_history` handler to `action_pull_station_conditions`, aligning it with the new API and data model. Removed logic for managing historical data timestamps (`app/actions/handlers.py`, [app/actions/handlers.pyL116-L144](diffhunk://#diff-f575ea29ea1c9649ccb87f9c38a0fd9a78b9f210c9e5e9d800e328ee30d08113L116-L144)).
* Updated the `transform` function to handle `conditions` instead of `history` and adjusted data processing accordingly (`app/actions/handlers.py`, [app/actions/handlers.pyL23-R28](diffhunk://#diff-f575ea29ea1c9649ccb87f9c38a0fd9a78b9f210c9e5e9d800e328ee30d08113L23-R28)).

### Test Updates:
* Refactored test cases to reflect the renaming and new functionality, including updates to mock responses and assertions (`app/actions/tests/test_handlers.py`, [[1]](diffhunk://#diff-1d3087a4c8f5f87d441341225d93eba5a73d22523ef90b8f1903714bc31eb11fL6-R7) [[2]](diffhunk://#diff-1d3087a4c8f5f87d441341225d93eba5a73d22523ef90b8f1903714bc31eb11fL38-R38) [[3]](diffhunk://#diff-1d3087a4c8f5f87d441341225d93eba5a73d22523ef90b8f1903714bc31eb11fL127-R125).